### PR TITLE
Update "Careers" link and add azavea.com link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+
+## Testing Instructions
+
+ * How to test this PR
+ * Prefer bulleted description
+ * Start after checking out this branch
+ * Include any setup required, such as bundling scripts, restarting services, etc.
+ * Include test case, and expected output
+
+Closes #XXX

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -39,7 +39,7 @@
           <li><a href="https://www.azavea.com/about/">About</a></li>
           <li><a href="https://www.azavea.com/work/">What we do</a></li>
           <li><a href="https://www.azavea.com/research/">Research</a></li>
-          <li><a href="http://jobs.azavea.com/">Jobs</a></li>
+          <li><a href="https://careers.azavea.com/">Careers</a></li>
           <li><a href="https://www.azavea.com/blog/">Blog</a></li>
           <li><a href="https://www.azavea.com/press/">Press</a></li>
         </ul>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -38,5 +38,8 @@
         {% endif %}
       </nav>
     </div>
+    <a href="https://www.azavea.com" class="azavea-link" title="Azavea homepage">
+      Go to azavea.com
+    </a>
   </div>
 </div>

--- a/_sass/layout/_navbar.scss
+++ b/_sass/layout/_navbar.scss
@@ -3,23 +3,37 @@
   position: absolute;
   z-index: 100;
   width: 100%;
-  padding: 2rem;
+  padding: 3rem 2rem 2rem;
   left: 0;
   top: 1rem;
+
+  @include respond-to('xs') {
+    padding: 0;
+    top: 5px;
+  }
 
   .container {
     display: flex;
     max-width: 1190px;
+    position: relative;
 
     @include respond-to('xs') {
       flex-direction: column;
       text-align: center;
+      padding-left: 0;
+      padding-right: 0;
     }
   }
 
   nav {
     display: inline-block;
     vertical-align: middle;
+
+    @include respond-to('xs') {
+      .btn {
+        margin-top: 1rem;
+      }
+    }
 
     a:not(.btn) {
       font-size: 1.6rem;
@@ -67,6 +81,11 @@
 
 .navbar-left {
   flex: 1;
+
+  @include respond-to('xs') {
+    text-align: left;
+    padding-left: 2.5rem;
+  }
 }
 
 .navbar-right {
@@ -84,5 +103,31 @@
   > img {
     width: 14.5rem;
     vertical-align: middle;
+  }
+}
+
+.azavea-link {
+  font-size: $a-font-size;
+  font-weight: $a-font-weight;
+  color: $a-link-color;
+  background: $a-link-background;
+  padding: 1rem 2rem 1rem;
+  border-radius: 0 0 4px 4px;
+  right: 2rem;
+  top: -4rem;
+  line-height: 1;
+  box-shadow: 0 0 10px $a-box-shadow-color;
+  position: absolute;
+
+  @include respond-to('xs') {
+    top: -5px;
+    margin-right: 2.5rem;
+    right: 0;
+  }
+
+  &:hover {
+    color: $primary;
+    cursor: pointer;
+    text-decoration: underline;
   }
 }

--- a/_sass/settings/_colors.scss
+++ b/_sass/settings/_colors.scss
@@ -14,3 +14,14 @@ $white: #fff;
 $off-white: #F4F6F8;
 
 $red: #d84d47;
+
+/**
+ * Grayscale
+ */
+$brand-ink: #27323D;
+$brand-granite: #4D6379;
+$brand-slate: #7C94AC;
+$brand-pewter: #B8C5D2;
+$brand-steel: #D0D9E1;
+$brand-porcelain: #E5EAEE;
+$brand-off-white: #F4F6F8;

--- a/_sass/settings/_variables.scss
+++ b/_sass/settings/_variables.scss
@@ -36,3 +36,11 @@ $focus-state: 0 0 0 3px rgba(lighten($primary, 10%), .4);
  * Shadows
  * * * */
 $shadow-default: 0 24px 32px rgba($black, .1);
+
+
+// Go to Azavea Navbar link:
+$a-font-size: 1.25rem;
+$a-font-weight: 400;
+$a-link-background: $brand-granite;
+$a-link-color: $white;
+$a-box-shadow-color: $brand-ink;


### PR DESCRIPTION
# Overview
- Updates footer link so that Jobs is renamed to "Careers"
- Add new "Go to azavea.com" link
- Visual adjustment to navigation for mobile
- Added PR template

# Demo 
Footer link
<img width="1230" alt="azavea_open_source_fellowship_-_home" src="https://user-images.githubusercontent.com/5672295/45049195-e53fce80-b04b-11e8-8b57-c2ac04043921.png">

New "Go to azavea" link
![screen shot 2018-09-04 at 2 03 21 pm](https://user-images.githubusercontent.com/5672295/45049213-f25cbd80-b04b-11e8-93ff-689f09078127.png)
<img width="1376" alt="screen shot 2018-09-04 at 2 04 55 pm" src="https://user-images.githubusercontent.com/5672295/45049216-f4bf1780-b04b-11e8-8cc9-ad1c4843ff21.png">

# Notes
- The "Go to Azavea" tab admittedly looks a little awkward overtop of the button. If you have thoughts about how to make this better let me know! For now, I just lightened the background of the tab so it stands up better against the dark background (still passes color contrast).
- The "Receive Alerts" button in the navigation goes to another line for mobile , so I just added a little padding overtop. If we instead want to use the same mobile navigation as on careers.azavea.com let me know!