### PR TITLE
Fix Vagrant ansible_local provisioner failing on trusty64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 ANSIBLE_VERSION = "2.4.*"
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.synced_folder "./", "/vagrant"
   config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"

--- a/deployment/ansible/fellowship.yml
+++ b/deployment/ansible/fellowship.yml
@@ -7,6 +7,4 @@
       apt: update_cache=yes cache_valid_time=3600
 
   roles:
-    - role: "azavea.python-security"
-      when: ansible_python_version | version_compare('2.7.9', '<')
     - role: "fellowship.docker"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,9 +1,6 @@
 ---
-- src: azavea.python-security
-  version: 0.1.0
-
 - src: azavea.pip
-  version: 1.0.0
+  version: 1.0.1
 
 - src: azavea.docker
   version: 4.0.0


### PR DESCRIPTION
## Overview

* Bump Vagrant box
* Remove python-security ansible role
* Bump pip ansible role version

Connects https://github.com/azavea/operations/issues/214

## Testing Instructions

Provision the VM from scratch:

```bash
$ vagrant destroy -f && ./scripts/setup
```

Bring a development server up from within the VM:

```bash
$ vagrant ssh
vagrant@vagrant:/vagrant$ ./scripts/server
...
```

Test in your browser with link in the `server` output.