### PR TITLE
Add hiatus banner and update config for date variable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ github_username:  azavea
 
 fellowship_in_session: false # is there a fellowship upcoming or in session
 fellowship_suspended: true # is the fellowship suspended for this year
-fellowship_timeframe: Summer 2020
+fellowship_timeframe: Summer 2021
 
 collections:
   projects:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,6 +34,10 @@
   {% if page.page_class %}
     class="{{- page.page_class }} {{ layout.page_class -}}"
   {% endif %}>
+  <div class="banner">
+    <h4>The Open Source Fellowship will be on hiatus in 2021</h4>
+    <p>If you have questions please <a href="https://www.azavea.com/contact-us/">contact us</a></p>
+  </div>
   {% include navbar.html %}
   {% if layout.use-alternate-hero %}
   {% include hero-alt.html %}

--- a/_sass/components/_banner.scss
+++ b/_sass/components/_banner.scss
@@ -1,0 +1,19 @@
+.banner {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  background: #0a2253;
+  display: flex;
+  z-index: 9999;
+  color: white;
+  padding: 15px;
+  text-align: center;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+
+  h4, p {
+    color: white;
+    margin: 0;
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -39,6 +39,7 @@
  * Components
  * * * */
 @import
+  "components/banner",
   "components/button",
   "components/call-to-action",
   "components/carousel",

--- a/page-faq.md
+++ b/page-faq.md
@@ -18,7 +18,7 @@ hero:
 
 {% if site.fellowship_suspended %}
 {:.faq #faq-0}
-#### [#](#faq-0){:class="anchor-link" title="anchor link"} Why is there a hiatus for Summer of 2020?
+#### [#](#faq-0){:class="anchor-link" title="anchor link"} Why is there a hiatus for {{ site.fellowship_timeframe }}?
 Azavea will not be running the Fellowship in {{ site.fellowship_timeframe }}. This is due to the company staff workload, resourcing priorities and the lack of available mentors this summer. We aim to run the program again next year.
 
 {% endif %}


### PR DESCRIPTION
## Overview
The Fellowship isn't going forward in 2021, so this PR adds the same banner that we have for Summer of Maps (though "contact us" goes to Azavea's contact page). I also updated a config variable for the year, so that areas that reference "Summer of 2020" are updated accordingly.

### Demo
<img width="1233" alt="Screen Shot 2020-12-23 at 11 04 59 PM" src="https://user-images.githubusercontent.com/5672295/103029756-e7f3c400-4573-11eb-9f28-4fb12dc9951c.png">
<img width="1233" alt="Screen Shot 2020-12-23 at 11 05 04 PM" src="https://user-images.githubusercontent.com/5672295/103029764-ecb87800-4573-11eb-95e2-762cc2187b4b.png">


## Testing Instructions
* `git pull`
* Note the new banner, click on the link and you should be redirected to Azavea's "Contact us" page
* Check areas where "Summer of 2020" would appear and confirm they say "Summer of 2021" now.


Connects https://github.com/azavea/azavea-marketing/issues/281
